### PR TITLE
added `emits` prop to support Vue 3 syntax

### DIFF
--- a/src/A11yDialog.vue
+++ b/src/A11yDialog.vue
@@ -51,6 +51,8 @@
       role: { type: String, default: 'dialog' }
     },
 
+    emits: ['dialog-ref'],
+
     computed: {
       fullTitleId () {
         return this.titleId || this.id + '-title'


### PR DESCRIPTION
prevents warnings from being reported in the console